### PR TITLE
v0.3: Option to remove footnotes added

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Kirby Footnotes v0.2
+Kirby Footnotes v0.3
 ============
 
 This plugin extends [Kirby 2 CMS](http://getkirby.com) with some basic and extremely easy footnote functionalities. The syntax is simple to understand and if the plugin is removed the remaining text still makes sense.
@@ -33,6 +33,10 @@ c::set('footnotes.smoothscroll', true);
 c::set('footnotes.offset', 0);
 ```
 
+If you wanna show the footnotes on certain pages (e.g. single article) but not on others (e.g. on the blog overview), you can add a parameter to the footnotes field method and it will remove all footnotes (the in-text references and the list):
+```php
+echo $post->text()->footnotes(false)->kirbytext();
+```
 
 # Usage
 Adding footnotes to your Kirbytext field is simple. Just type them inline in your post in square brackets like this:

--- a/site/plugins/footnotes/footnotes.php
+++ b/site/plugins/footnotes/footnotes.php
@@ -18,7 +18,7 @@ function convert_footnotes($text) {
     }
 
 
-    if (true) { // TODO: if is single article
+    if (true) { // TODO: maybe add filter for specific templates
         $text .= "<div class='footnotes' id='footnotes'>";
         $text .= "<div class='footnotedivider'></div>";
 
@@ -37,17 +37,29 @@ function convert_footnotes($text) {
     return $text;
   }
 
-  $value = $text;
+  return $text;
+}
 
-  return $value;
+function remove_footnotes($text) {
+  if (preg_match_all('/\[(\d+\. .*?)\]/s', $text, $matches)) {
+    foreach ($matches[0] as $fn) {
+        $note = preg_replace('/\[\d+\. (.*?)\]/s', '\1', $fn);
+        $text = str_replace($fn, "", $text);
+    }
+  }
+  return $text;
 }
 
 
 /**
  * Adding an footnotes field method: e.g. $page->text()->footnotes()->kirbytext()
  */
-field::$methods['footnotes'] = function($field) {
-  $field->value = convert_footnotes($field->value);
+field::$methods['footnotes'] = function($field, $nodisplay=false) {
+  if ($nodisplay) {
+    $field->value = remove_footnotes($field->value);
+  } else {
+    $field->value = convert_footnotes($field->value);
+  }
   return $field;
 };
 


### PR DESCRIPTION
If you wanna show the footnotes on certain pages (e.g. single article) but not on others (e.g. on the blog overview), you can add a parameter to the footnotes field method and it will remove all footnotes (the in-text references and the list):
```php
echo $post->text()->footnotes(false)->kirbytext();
```